### PR TITLE
Support for Huggingface interference API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mule.mulechain</groupId>
 	<artifactId>mulechain-ai-connector</artifactId>
-	<version>0.3.2-SNAPSHOT</version>
+	<version>0.3.13-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 
@@ -198,6 +198,11 @@
 		<dependency>
 			<groupId>dev.langchain4j</groupId>
 			<artifactId>langchain4j-mistral-ai</artifactId>
+			<version>${langchain4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>dev.langchain4j</groupId>
+			<artifactId>langchain4j-hugging-face</artifactId>
 			<version>${langchain4j.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mule.mulechain</groupId>
 	<artifactId>mulechain-ai-connector</artifactId>
-	<version>0.3.13-SNAPSHOT</version>
+	<version>0.3.18-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 

--- a/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
@@ -5,6 +5,7 @@ package org.mule.extension.mulechain.internal.config.util;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
+import dev.langchain4j.model.huggingface.HuggingFaceChatModel;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
 import dev.langchain4j.model.ollama.OllamaChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
@@ -75,6 +76,21 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .temperature(configuration.getTemperature())
         .timeout(ofSeconds(durationInSec))
+        .build();
+  }
+
+
+  public static HuggingFaceChatModel createHuggingFaceChatModel(ConfigExtractor configExtractor,
+                                                                LangchainLLMConfiguration configuration) {
+    String huggingFaceApiKey = configExtractor.extractValue("HUGGING_FACE_API_KEY");
+    long durationInSec = configuration.getLlmTimeoutUnit().toSeconds(configuration.getLlmTimeout());
+    return HuggingFaceChatModel.builder()
+        .accessToken(huggingFaceApiKey)
+        .modelId(configuration.getModelName())
+        .timeout(ofSeconds(durationInSec))
+        .temperature(configuration.getTemperature())
+        .maxNewTokens(configuration.getMaxTokens())
+        .waitForModel(true)
         .build();
   }
 

--- a/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
@@ -22,21 +22,21 @@ public final class ResponseHelper {
   public static Result<InputStream, LLMResponseAttributes> createLLMResponse(String response,
                                                                              dev.langchain4j.service.Result<?> result,
                                                                              Map<String, String> responseAttributes) {
-    TokenUsage tokenUsage = result != null ? new TokenUsage(result.tokenUsage().inputTokenCount(),
-                                                            result.tokenUsage().outputTokenCount(),
-                                                            result.tokenUsage().totalTokenCount())
+
+    TokenUsage tokenUsage = result.tokenUsage() != null ? new TokenUsage(result.tokenUsage().inputTokenCount(),
+                                                                         result.tokenUsage().outputTokenCount(),
+                                                                         result.tokenUsage().totalTokenCount())
         : null;
 
-    System.out.println(response + ", " + tokenUsage + ", " + responseAttributes);
     return createLLMResponse(response, tokenUsage, responseAttributes);
   }
 
   public static Result<InputStream, LLMResponseAttributes> createLLMResponse(String response,
                                                                              Response<?> result,
                                                                              Map<String, String> responseAttributes) {
-    TokenUsage tokenUsage = result != null ? new TokenUsage(result.tokenUsage().inputTokenCount(),
-                                                            result.tokenUsage().outputTokenCount(),
-                                                            result.tokenUsage().totalTokenCount())
+    TokenUsage tokenUsage = result.tokenUsage() != null ? new TokenUsage(result.tokenUsage().inputTokenCount(),
+                                                                         result.tokenUsage().outputTokenCount(),
+                                                                         result.tokenUsage().totalTokenCount())
         : null;
     return createLLMResponse(response, tokenUsage, responseAttributes);
   }

--- a/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
@@ -26,6 +26,8 @@ public final class ResponseHelper {
                                                             result.tokenUsage().outputTokenCount(),
                                                             result.tokenUsage().totalTokenCount())
         : null;
+
+    System.out.println(response + ", " + tokenUsage + ", " + responseAttributes);
     return createLLMResponse(response, tokenUsage, responseAttributes);
   }
 

--- a/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
@@ -23,7 +23,10 @@ public enum LangchainLLMType {
           getMistralAIModelNameStream(), LangchainLLMInitializerUtil::createMistralAiChatModel), OLLAMA("OLLAMA",
               getOllamaModelNameStream(), LangchainLLMInitializerUtil::createOllamaChatModel), ANTHROPIC("ANTHROPIC",
                   getAnthropicModelNameStream(), LangchainLLMInitializerUtil::createAnthropicChatModel), AZURE_OPENAI(
-                      "AZURE_OPENAI", OPENAI.getModelNameStream(), LangchainLLMInitializerUtil::createAzureOpenAiChatModel);
+                      "AZURE_OPENAI", OPENAI.getModelNameStream(),
+                      LangchainLLMInitializerUtil::createAzureOpenAiChatModel), HUGGING_FACE(
+                          "HUGGING_FACE", getHuggingFaceModelNameStream(),
+                          LangchainLLMInitializerUtil::createHuggingFaceChatModel);
 
   private final String value;
   private final Stream<String> modelNameStream;
@@ -62,6 +65,10 @@ public enum LangchainLLMType {
     return Arrays.stream(OllamaModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getHuggingFaceModelNameStream() {
+    return Arrays.stream(HuggingFaceModelName.values()).map(String::valueOf);
+  }
+
   private static Stream<String> getAnthropicModelNameStream() {
     return Arrays.stream(AnthropicChatModelName.values()).map(String::valueOf);
   }
@@ -87,4 +94,21 @@ public enum LangchainLLMType {
       return this.value;
     }
   }
+
+  enum HuggingFaceModelName {
+    TII_UAE_FALCON_7B_INSTRUCT("tiiuae/falcon-7b-instruct"), PHI3("microsoft/Phi-3.5-mini-instruct"), MISTRAL_7B_INSTRUCT_v03(
+        "mistralai/Mistral-7B-Instruct-v0.3"), TINY_LLAMA("TinyLlama/TinyLlama-1.1B-Chat-v1.0");
+
+    private final String value;
+
+    HuggingFaceModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+  }
+
 }


### PR DESCRIPTION
**Huggingface support added**,

- configuration item for hugging face added
- modellist includes 4 models as example to be used, additional models can be entered in the model field of the configuration in plaintext from https://huggingface.co/
- All chat operation are enabled
- Tools only work for models supporting tools
- image operations are not supported
- Currently huggingface interference API doesn't support tokenUsage. 

Here is an example configuration of the model `mistralai/Mixtral-8x7B-Instruct-v0.1`
<img width="625" alt="image" src="https://github.com/user-attachments/assets/5a33edbf-2623-4c44-9b7a-ae8e431dbc19">

