### PR TITLE
Gemini ChatModel Added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.10-SNAPSHOT</version>
+	<version>1.1.11-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 
@@ -200,6 +200,7 @@
 			<artifactId>langchain4j-mistral-ai</artifactId>
 			<version>${langchain4j.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>dev.langchain4j</groupId>
 			<artifactId>langchain4j-hugging-face</artifactId>
@@ -239,6 +240,11 @@
 		<dependency>
 			<groupId>dev.langchain4j</groupId>
 			<artifactId>langchain4j-azure-open-ai</artifactId>
+			<version>${langchain4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>dev.langchain4j</groupId>
+			<artifactId>langchain4j-google-ai-gemini</artifactId>
 			<version>${langchain4j.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.11-SNAPSHOT</version>
+	<version>1.1.13-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.21-SNAPSHOT</version>
+	<version>1.1.28-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.13-SNAPSHOT</version>
+	<version>1.1.21-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 

--- a/src/main/java/org/mule/extension/mulechain/internal/config/LangchainLLMConfiguration.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/config/LangchainLLMConfiguration.java
@@ -68,19 +68,25 @@ public class LangchainLLMConfiguration implements Initialisable {
 
   @Parameter
   @Placement(order = 6, tab = Placement.DEFAULT_TAB)
+  @Optional(defaultValue = "0.95")
+  private double topP = 0.95;
+
+
+  @Parameter
+  @Placement(order = 7, tab = Placement.DEFAULT_TAB)
   @Optional(defaultValue = "60")
   @DisplayName("LLM timeout")
   private int llmTimeout = 60;
 
   @Parameter
   @Optional(defaultValue = "SECONDS")
-  @Placement(order = 7, tab = Placement.DEFAULT_TAB)
+  @Placement(order = 8, tab = Placement.DEFAULT_TAB)
   @DisplayName("LLM timeout unit")
   @Summary("Time unit to be used in the LLM Timeout")
   private TimeUnit llmTimeoutUnit = TimeUnit.SECONDS;
 
   @Parameter
-  @Placement(order = 8, tab = Placement.DEFAULT_TAB)
+  @Placement(order = 9, tab = Placement.DEFAULT_TAB)
   @Expression(ExpressionSupport.SUPPORTED)
   @Optional(defaultValue = "500")
   private int maxTokens = 500;
@@ -108,6 +114,11 @@ public class LangchainLLMConfiguration implements Initialisable {
   public double getTemperature() {
     return temperature;
   }
+
+  public double getTopP() {
+    return topP;
+  }
+
 
   public int getLlmTimeout() {
     return llmTimeout;

--- a/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
@@ -5,6 +5,7 @@ package org.mule.extension.mulechain.internal.config.util;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.azure.AzureOpenAiChatModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import dev.langchain4j.model.huggingface.HuggingFaceChatModel;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
 import dev.langchain4j.model.ollama.OllamaChatModel;
@@ -26,6 +27,7 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .maxTokens(configuration.getMaxTokens())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .logRequests(true)
         .logResponses(true)
@@ -43,6 +45,7 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .maxTokens(configuration.getMaxTokens())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .logRequests(true)
         .logResponses(true)
@@ -61,6 +64,7 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .maxTokens(configuration.getMaxTokens())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .logRequests(true)
         .logResponses(true)
@@ -75,6 +79,7 @@ public final class LangchainLLMInitializerUtil {
         .baseUrl(ollamaBaseUrl)
         .modelName(configuration.getModelName())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .build();
   }
@@ -95,6 +100,21 @@ public final class LangchainLLMInitializerUtil {
   }
 
 
+  public static GoogleAiGeminiChatModel createGoogleGeminiChatModel(ConfigExtractor configExtractor,
+                                                                    LangchainLLMConfiguration configuration) {
+    String geminiAiKey = configExtractor.extractValue("GEMINI_AI_KEY");
+    long durationInSec = configuration.getLlmTimeoutUnit().toSeconds(configuration.getLlmTimeout());
+    return GoogleAiGeminiChatModel.builder()
+        .apiKey(geminiAiKey)
+        .modelName(configuration.getModelName())
+        .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
+        .maxOutputTokens(configuration.getMaxTokens())
+        .logRequestsAndResponses(true)
+        .build();
+  }
+
+
   public static AnthropicChatModel createAnthropicChatModel(ConfigExtractor configExtractor,
                                                             LangchainLLMConfiguration configuration) {
     String anthropicApiKey = configExtractor.extractValue("ANTHROPIC_API_KEY");
@@ -105,6 +125,7 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .maxTokens(configuration.getMaxTokens())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .logRequests(true)
         .logResponses(true)
@@ -124,6 +145,7 @@ public final class LangchainLLMInitializerUtil {
         .deploymentName(azureOpenaiDeploymentName)
         .maxTokens(configuration.getMaxTokens())
         .temperature(configuration.getTemperature())
+        .topP(configuration.getTopP())
         .timeout(ofSeconds(durationInSec))
         .logRequestsAndResponses(true)
         .build();

--- a/src/main/java/org/mule/extension/mulechain/internal/constants/MuleChainConstants.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/constants/MuleChainConstants.java
@@ -18,6 +18,7 @@ public class MuleChainConstants {
   public static final String DB_FILE_PATH = "dbFilePath";
   public static final String MAX_MESSAGES = "maxMessages";
   public static final String TOOLS_USED = "toolsUsed";
+  public static final String TOOL_EXECUTION_REQUESTS = "toolExecutionRequests";
   public static final String STATUS = "status";
   public static final String STORE_NAME = "storeName";
   public static final String CREATED = "created";

--- a/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/helpers/ResponseHelper.java
@@ -44,6 +44,7 @@ public final class ResponseHelper {
   public static Result<InputStream, LLMResponseAttributes> createLLMResponse(String response,
                                                                              TokenUsage tokenUsage,
                                                                              Map<String, String> responseAttributes) {
+
     return Result.<InputStream, LLMResponseAttributes>builder()
         .attributes(new LLMResponseAttributes(tokenUsage, (HashMap<String, String>) responseAttributes))
         .attributesMediaType(org.mule.runtime.api.metadata.MediaType.APPLICATION_JAVA)

--- a/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
@@ -26,7 +26,9 @@ public enum LangchainLLMType {
                       "AZURE_OPENAI", OPENAI.getModelNameStream(),
                       LangchainLLMInitializerUtil::createAzureOpenAiChatModel), HUGGING_FACE(
                           "HUGGING_FACE", getHuggingFaceModelNameStream(),
-                          LangchainLLMInitializerUtil::createHuggingFaceChatModel);
+                          LangchainLLMInitializerUtil::createHuggingFaceChatModel), GEMINI_AI("GEMINI_AI",
+                              getGoogleGeminiModelNameStream(),
+                              LangchainLLMInitializerUtil::createGoogleGeminiChatModel);
 
   private final String value;
   private final Stream<String> modelNameStream;
@@ -69,6 +71,11 @@ public enum LangchainLLMType {
     return Arrays.stream(HuggingFaceModelName.values()).map(String::valueOf);
   }
 
+  private static Stream<String> getGoogleGeminiModelNameStream() {
+    return Arrays.stream(GeminiModelName.values()).map(String::valueOf);
+  }
+
+
   private static Stream<String> getAnthropicModelNameStream() {
     return Arrays.stream(AnthropicChatModelName.values()).map(String::valueOf);
   }
@@ -102,6 +109,22 @@ public enum LangchainLLMType {
     private final String value;
 
     HuggingFaceModelName(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return this.value;
+    }
+  }
+
+  enum GeminiModelName {
+    GEMINI_1_5_FLASH("gemini-1.5-flash"), GEMINI_1_5_PRO("gemini-1.5-pro"), GEMINI_1_PRO(
+        "gemini-1.0-pro"), AQA("aqa");
+
+    private final String value;
+
+    GeminiModelName(String value) {
       this.value = value;
     }
 

--- a/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/llm/type/LangchainLLMType.java
@@ -120,7 +120,7 @@ public enum LangchainLLMType {
 
   enum GeminiModelName {
     GEMINI_1_5_FLASH("gemini-1.5-flash"), GEMINI_1_5_PRO("gemini-1.5-pro"), GEMINI_1_PRO(
-        "gemini-1.0-pro"), AQA("aqa");
+        "gemini-1.0-pro");
 
     private final String value;
 

--- a/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainEmbeddingStoresOperations.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainEmbeddingStoresOperations.java
@@ -652,6 +652,7 @@ public class LangchainEmbeddingStoresOperations {
       LOGGER.debug("Intermediate Answer containing the request URLs: {}", intermediateAnswer.content());
       //String response = model.generate(data);
       Result<String> response = assistantChat.chat(data);
+
       List<String> findURLs = extractUrls(intermediateAnswer.content());
       boolean toolsUsed = false;
       if (findURLs != null) {

--- a/src/main/resources/api/response/ResponseTools.json
+++ b/src/main/resources/api/response/ResponseTools.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "response": {
+      "type": "string"
+    },
+    "toolExecutionRequests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Added Chatmodel support for Google Gemini AI. 

**Tested successfully** on following operations:
- Agent define prompt template
- Chat answer prompt
- Chat answer prompt with memory
- Get Info from store
- RAG load document
- Sentiment analyze
- Read scanned document

_Tools AI Service is not supported in this change. We will add it at a later stage._ 

FYA: Vertex AI will be added to MAC Inference connector at a later stage. 


