### PR TITLE
Upgraded LangChain4J to 0.35.0 (latest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.36-SNAPSHOT</version>
+	<version>1.1.37-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mulesoft.connectors</groupId>
 	<artifactId>mule4-aichain-connector</artifactId>
-	<version>1.1.33-SNAPSHOT</version>
+	<version>1.1.36-SNAPSHOT</version>
 	<packaging>mule-extension</packaging>
 	<name>MuleSoft AI Chain Connector - Mule 4</name>
 
@@ -22,7 +22,7 @@
 		<formatterGoal>validate</formatterGoal>
 		<slf4jApi.version>2.0.7</slf4jApi.version>
 		<mule.sdk.api.version>0.9.0-rc1</mule.sdk.api.version>
-		<langchain4j.version>0.34.0</langchain4j.version> <!-- upgrade to support tools in Ollama -->
+		<langchain4j.version>0.35.0</langchain4j.version> <!-- upgrade to support tools in Ollama -->
 		<mapdb.version>3.1.0</mapdb.version>
 		<json.version>20240303</json.version>
 		<munit.input.directory>src/test/munit</munit.input.directory>

--- a/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/config/util/LangchainLLMInitializerUtil.java
@@ -109,8 +109,9 @@ public final class LangchainLLMInitializerUtil {
         .modelName(configuration.getModelName())
         .temperature(configuration.getTemperature())
         .topP(configuration.getTopP())
+        .timeout(ofSeconds(durationInSec))
         .maxOutputTokens(configuration.getMaxTokens())
-        .logRequestsAndResponses(true)
+        .logRequestsAndResponses(false)
         .build();
   }
 

--- a/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainEmbeddingStoresOperations.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainEmbeddingStoresOperations.java
@@ -71,7 +71,6 @@ import dev.langchain4j.chain.ConversationalRetrievalChain;
 import dev.langchain4j.data.document.loader.UrlDocumentLoader;
 import dev.langchain4j.data.document.parser.TextDocumentParser;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
-import dev.langchain4j.data.document.transformer.HtmlTextExtractor;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -216,9 +215,11 @@ public class LangchainEmbeddingStoresOperations {
                                     e);
         }
 
-        Document htmlDocument = UrlDocumentLoader.load(url, new TextDocumentParser());
-        HtmlTextExtractor transformer = new HtmlTextExtractor(null, null, true);
-        document = transformer.transform(htmlDocument);
+        //Document htmlDocument = UrlDocumentLoader.load(url, new TextDocumentParser());
+        document = UrlDocumentLoader.load(url, new TextDocumentParser());
+
+        /*HtmlToTextDocumentTransformer transformer = new HtmlToTextDocumentTransformer(null, null, true);
+        document = transformer.transform(htmlDocument);*/
         document.metadata().add("url", contextPath);
         ingestor.ingest(document);
         break;

--- a/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainLLMOperations.java
+++ b/src/main/java/org/mule/extension/mulechain/internal/operation/LangchainLLMOperations.java
@@ -195,7 +195,7 @@ public class LangchainLLMOperations {
 
       String response = executeREST(openaiApiKey, payload.toString());
       JSONObject jsonObject = new JSONObject();
-      jsonObject.put(MuleChainConstants.RESPONSE, response);
+      jsonObject.put(MuleChainConstants.RESPONSE, new JSONObject(response));
 
       LOGGER.debug("Toxicity detection result {}", response);
       Result<String> answer = Result.<String>builder()


### PR DESCRIPTION
### Upgraded to LangChain4J 0.35.0 Version
- **Google Gemini Timeout fixed**
- **Google Gemini Logging Fixed**
- **Image read now with file possible**
